### PR TITLE
Fix Close propagation error

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -58,7 +58,7 @@ func (ln *GracefulListener) Close() error {
 	err := ln.ln.Close()
 
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return ln.waitForZeroConns()


### PR DESCRIPTION
Hello

in the original snippet from fasthttp issue comments, there was this problem when we check if ln.ln.Close returns error, then we return *nil* instead the original error. here is the fix